### PR TITLE
accept and default offsets to `Vector{Int32}` for VectorOfArrays

### DIFF
--- a/src/vector_of_arrays.jl
+++ b/src/vector_of_arrays.jl
@@ -490,7 +490,7 @@ function consgrouped_ptrs end
 export consgrouped_ptrs
 
 function consgrouped_ptrs(A::AbstractVector)
-    elem_ptr = sizehint!(Int32[], length(A))
+    elem_ptr = Vector{Int}()
     idxs = eachindex(A)
     push!(elem_ptr, first(idxs))
     if !isempty(A)

--- a/src/vector_of_arrays.jl
+++ b/src/vector_of_arrays.jl
@@ -26,7 +26,7 @@ VectorOfArrays{T,N}(A::AbstractVector{<:AbstractArray})
 
 VectorOfArrays(
     data::AbstractVector,
-    elem_ptr::AbstractVector{Int},
+    elem_ptr::AbstractVector{<:Integer},
     kernel_size::AbstractVector{<:Dims}
     checks::Function = ArraysOfArrays.full_consistency_checks
 )
@@ -44,7 +44,7 @@ and `ArraysOfArrays.no_consistency_checks`.
 struct VectorOfArrays{
     T, N, M,
     VT<:AbstractVector{T},
-    VI<:AbstractVector{Int},
+    VI<:AbstractVector{<:Integer},
     VD<:AbstractVector{Dims{M}}
 } <: AbstractVector{Array{T,N}}
     data::VT
@@ -73,7 +73,7 @@ struct VectorOfArrays{
     ) where {
         T, M,
         VT<:AbstractVector{T},
-        VI<:AbstractVector{Int},
+        VI<:AbstractVector{<:Integer},
         VD<:AbstractVector{Dims{M}}
     }
         N = length((ntuple(_ -> 0, Val{M}())..., 0))
@@ -429,7 +429,7 @@ VectorOfVectors(A::AbstractVector{<:AbstractVector})
 VectorOfVectors{T}(A::AbstractVector{<:AbstractVector}) where {T}
 
 VectorOfVectors(
-    data::AbstractVector, elem_ptr::AbstractVector{Int},
+    data::AbstractVector, elem_ptr::AbstractVector{<:Integer},
     checks::Function = full_consistency_checks
 )
 
@@ -439,7 +439,7 @@ See also [VectorOfArrays](@ref).
 const VectorOfVectors{
     T,
     VT<:AbstractVector{T},
-    VI<:AbstractVector{Int},
+    VI<:AbstractVector{<:Integer},
     VD<:AbstractVector{Dims{0}}
 } = VectorOfArrays{T,1,0,VT,VI,VD}
 
@@ -452,9 +452,9 @@ VectorOfVectors(A::AbstractVector{<:AbstractVector}) = VectorOfArrays(A)
 
 VectorOfVectors(
     data::AbstractVector,
-    elem_ptr::AbstractVector{Int},
+    elem_ptr::AbstractVector{I},
     checks::Function = full_consistency_checks
-) = VectorOfArrays(
+) where I <: Integer= VectorOfArrays(
     data,
     elem_ptr,
     similar(elem_ptr, Dims{0}, size(elem_ptr, 1) - 1),
@@ -490,7 +490,7 @@ function consgrouped_ptrs end
 export consgrouped_ptrs
 
 function consgrouped_ptrs(A::AbstractVector)
-    elem_ptr = Vector{Int}()
+    elem_ptr = sizehint!(Int32[], length(A))
     idxs = eachindex(A)
     push!(elem_ptr, first(idxs))
     if !isempty(A)

--- a/test/vector_of_arrays.jl
+++ b/test/vector_of_arrays.jl
@@ -301,11 +301,14 @@ using ArraysOfArrays: full_consistency_checks, append_elemptr!, element_ptr
         A = [1, 1, 2, 3, 3, 2, 2, 2]
         A_grouped_ref = [[1, 1], [2], [3, 3], [2, 2, 2]]
         elem_ptr = consgrouped_ptrs(A)
+        elem_ptr32 = Int32.(consgrouped_ptrs(A))
         @test first.(@inferred(VectorOfVectors(A, elem_ptr))) == [1, 2, 3, 2]
+        @test first.(@inferred(VectorOfVectors(A, elem_ptr32))) == [1, 2, 3, 2]
 
         B = [1, 2, 3, 4, 5, 6, 7, 8]
         B_grouped_ref = [[1, 2], [3], [4, 5], [6, 7, 8]]
         @test @inferred(VectorOfVectors(B, elem_ptr)) == B_grouped_ref
+        @test @inferred(VectorOfVectors(B, elem_ptr32)) == B_grouped_ref
 
         C = [1.1, 2.2, 3.3, 4.4, 5.5, 6.6, 7.7, 8.8]
         C_grouped_ref = [[1.1, 2.2], [3.3], [4.4, 5.5], [6.6, 7.7, 8.8]]


### PR DESCRIPTION
fix #17

I doubt anyone will have vector longer than `typemax(Int32) 2147483647` but I'm fine if we still wants to default to `Int64` (or UInt32 maybe? since if user is `push!()`ing then they won't have negative index)

The reason why I think `Int32` is better is that it will fit more index into registers at once, faster when looping through.

Test all passes, and JETTest says okay:
```julia

julia> @report_dispatch VectorOfVectors(collect(1:10), Int32[1,5,8])
No errors !
(VectorOfVectors{Int64, Vector{Int64}, Vector{Int32}, Vector{Tuple{}}}, 0)
```