### PR TITLE
[WIP] Improve ArrayOfSimilarArrays and VectorOfArrays (breaking)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ArraysOfArrays"
 uuid = "65a8f2f4-9b39-5baf-92e2-a9cc46fdf018"
-version = "0.5.6"
+version = "0.6.0-DEV"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"


### PR DESCRIPTION
This PR is intended to accumulate breaking API changes for ArraysOfArrays v0.7 to address certain issues and add features required to support additional use cases.

* ~Remove `@require`s: @torfjelde and @cscherrer expressed interest to use ArraysOfArrays within the Turing (see TuringLang/Bijectors.jl#199) and MeasureTheory ecosystems, but the fact that ArraysOfArrays currently uses Requires makes that option less attractive. `ArrayOfSimilarArrays` was originally designed to represent vectors of vector-values samples (it originated within BAT.jl), so it would be a good fit.~

Update: #26 has removed all requires

 * ~~Supporting `StatsBase.mean` and friends with weights: If ArraysOfArrays can be made more lightweight, maybe it could become acceptable as a dependency for StatsBase. Semantically this would be nice, also for Distributions, since `ArrayOfSimilarArrays` resolved the confusion regarding which dimensions of a matrix are used for the "parameter" axis and the "n_th sample"-axis, with different defaults for `rand` and `cov` and so on. And things like `Distributions.likelihood` (already supports abstract vectors of vectors) could use fast matrix-backed implementations for `ArrayOfSimilarArrays`.~~

Update: StatsBase should handle this, the upcoming `Base.AbstractSlices` will provide a basis for specialized statistics operations on sliced arrays.

* ~~Supporting StaticArrays (using `nestedview` and `flatview` for zero-copy switching between matrix and vector-of-StaticArray representation). StaticArrays isn't very lightweight, but while ArraysOfArrays is very lean, it's not a super-slim API-only package either (but still lighter than StaticArrays). Could StaticArrays depend on ArraysOfArrays in principle? - @andyferris, @timholy may I pull you in here?~~

The new StaticArraysCore.jl allows us to support static arrays directly in ArraysOfArrays without heavy dependencies.

* [ ] Append-to-element-vectors support for `VectorOfArrays` (a vector of non-similar arrays, a.k.a a "ragged array"), #10: @mrVeng was missing the this ability. This can be done in an amortized fashion with a variant of `VectorOfArrays` (see https://discourse.julialang.org/t/elasticarrays-arraysofarrays-for-vector-of-arrays/70426/2). The `elem_ptr` vector will be replaced by a vector of ranges, the current behavior will be available via a custom `VectorOfContiguousRanges` type backed by what is currently `elem_ptr`.

* [ ] Finally address issue #2 (CC @Moelf).
