### PR TITLE
Fix stats functions signatures by adding `mean` keyword

### DIFF
--- a/src/array_of_similar_arrays.jl
+++ b/src/array_of_similar_arrays.jl
@@ -444,8 +444,8 @@ Statistics.std(X::AbstractVectorOfSimilarArrays{T,M}; corrected::Bool = true, me
 Compute the covariance matrix between the elements of the elements of `X`
 along `X`. Equivalent to `cov` of `flatview(X)` along dimension 2.
 """
-Statistics.cov(X::AbstractVectorOfSimilarVectors; corrected::Bool = true, mean = nothing) =
-    cov(flatview(X); dims = 2, corrected = corrected, mean = mean)
+Statistics.cov(X::AbstractVectorOfSimilarVectors; corrected::Bool = true) =
+    cov(flatview(X); dims = 2, corrected = corrected)
 
 
 """

--- a/src/array_of_similar_arrays.jl
+++ b/src/array_of_similar_arrays.jl
@@ -421,8 +421,8 @@ Statistics.mean(X::AbstractVectorOfSimilarArrays{T,M}) where {T,M} =
 Compute the sample variance of the elements vectors of `X`. Equivalent to
 `var` of `flatview(X)` along the last dimension.
 """
-Statistics.var(X::AbstractVectorOfSimilarArrays{T,M}; corrected::Bool = true) where {T,M} =
-    var(flatview(X); dims = M + 1, corrected = corrected)[_ncolons(Val{M}())...]
+Statistics.var(X::AbstractVectorOfSimilarArrays{T,M}; corrected::Bool = true, mean = nothing) where {T,M} =
+    var(flatview(X); dims = M + 1, corrected = corrected. mean = nothing)[_ncolons(Val{M}())...]
 
 
 """
@@ -433,8 +433,8 @@ Compute the sample standard deviation of the elements vectors of `X`.
 Compute the sample variance of the elements vectors of `X`. Equivalent to
 `std` of `flatview(X)` along the last dimension.
 """
-Statistics.std(X::AbstractVectorOfSimilarArrays{T,M}; corrected::Bool = true) where {T,M} =
-    std(flatview(X); dims = M + 1, corrected = corrected)[_ncolons(Val{M}())...]
+Statistics.std(X::AbstractVectorOfSimilarArrays{T,M}; corrected::Bool = true, mean = nothing) where {T,M} =
+    std(flatview(X); dims = M + 1, corrected = corrected, mean = mean)[_ncolons(Val{M}())...]
 
 
 """
@@ -444,8 +444,8 @@ Statistics.std(X::AbstractVectorOfSimilarArrays{T,M}; corrected::Bool = true) wh
 Compute the covariance matrix between the elements of the elements of `X`
 along `X`. Equivalent to `cov` of `flatview(X)` along dimension 2.
 """
-Statistics.cov(X::AbstractVectorOfSimilarVectors; corrected::Bool = true) =
-    cov(flatview(X); dims = 2, corrected = corrected)
+Statistics.cov(X::AbstractVectorOfSimilarVectors; corrected::Bool = true, mean = nothing) =
+    cov(flatview(X); dims = 2, corrected = corrected, mean = mean)
 
 
 """

--- a/src/array_of_similar_arrays.jl
+++ b/src/array_of_similar_arrays.jl
@@ -415,19 +415,19 @@ Statistics.mean(X::AbstractVectorOfSimilarArrays{T,M}) where {T,M} =
 
 
 """
-    var(X::AbstractVectorOfSimilarArrays; corrected::Bool = true)
-    var(X::AbstractVectorOfSimilarArrays, w::StatsBase.AbstractWeights; corrected::Bool = true)
+    var(X::AbstractVectorOfSimilarArrays; corrected::Bool = true, mean = nothing)
+    var(X::AbstractVectorOfSimilarArrays, w::StatsBase.AbstractWeights; corrected::Bool = true, mean = nothing)
 
 Compute the sample variance of the elements vectors of `X`. Equivalent to
 `var` of `flatview(X)` along the last dimension.
 """
 Statistics.var(X::AbstractVectorOfSimilarArrays{T,M}; corrected::Bool = true, mean = nothing) where {T,M} =
-    var(flatview(X); dims = M + 1, corrected = corrected, mean = nothing)[_ncolons(Val{M}())...]
+    var(flatview(X); dims = M + 1, corrected = corrected, mean = mean)[_ncolons(Val{M}())...]
 
 
 """
-    var(X::AbstractVectorOfSimilarArrays; corrected::Bool = true)
-    var(X::AbstractVectorOfSimilarArrays, w::StatsBase.AbstractWeights; corrected::Bool = true)
+    var(X::AbstractVectorOfSimilarArrays; corrected::Bool = true, mean = nothing)
+    var(X::AbstractVectorOfSimilarArrays, w::StatsBase.AbstractWeights; corrected::Bool = true, mean = nothing)
 
 Compute the sample standard deviation of the elements vectors of `X`.
 Compute the sample variance of the elements vectors of `X`. Equivalent to

--- a/src/array_of_similar_arrays.jl
+++ b/src/array_of_similar_arrays.jl
@@ -422,7 +422,7 @@ Compute the sample variance of the elements vectors of `X`. Equivalent to
 `var` of `flatview(X)` along the last dimension.
 """
 Statistics.var(X::AbstractVectorOfSimilarArrays{T,M}; corrected::Bool = true, mean = nothing) where {T,M} =
-    var(flatview(X); dims = M + 1, corrected = corrected. mean = nothing)[_ncolons(Val{M}())...]
+    var(flatview(X); dims = M + 1, corrected = corrected, mean = nothing)[_ncolons(Val{M}())...]
 
 
 """

--- a/src/statsbase_support.jl
+++ b/src/statsbase_support.jl
@@ -7,14 +7,14 @@ Base.sum(X::AbstractVectorOfSimilarArrays{T,M}, w::StatsBase.AbstractWeights) wh
 Statistics.mean(X::AbstractVectorOfSimilarArrays{T,M}, w::StatsBase.AbstractWeights) where {T,M} =
     mean(flatview(X), w, dims = M + 1)[_ncolons(Val{M}())...]
 
-Statistics.var(X::AbstractVectorOfSimilarArrays{T,M}, w::StatsBase.AbstractWeights; corrected::Bool = true) where {T,M} =
-    var(flatview(X), w, M + 1; corrected = corrected)[_ncolons(Val{M}())...]
+Statistics.var(X::AbstractVectorOfSimilarArrays{T,M}, w::StatsBase.AbstractWeights; mean = nothing, corrected::Bool = true) where {T,M} =
+    var(flatview(X), w, M + 1; mean = mean, corrected = corrected)[_ncolons(Val{M}())...]
 
 Statistics.std(X::AbstractVectorOfSimilarArrays{T,M}, w::StatsBase.AbstractWeights; mean = nothing, corrected::Bool = true) where {T,M} =
     std(flatview(X), w, M + 1; mean = mean, corrected = corrected)[_ncolons(Val{M}())...]
 
-Statistics.cov(X::AbstractVectorOfSimilarVectors, w::StatsBase.AbstractWeights; corrected::Bool = true) =
-    cov(flatview(X), w, 2; corrected = corrected)
+Statistics.cov(X::AbstractVectorOfSimilarVectors, w::StatsBase.AbstractWeights; mean = nothing, corrected::Bool = true) =
+    cov(flatview(X), w, 2; mean = mean, corrected = corrected)
 
 Statistics.cor(X::AbstractVectorOfSimilarVectors, w::StatsBase.AbstractWeights) =
     cor(flatview(X), w, 2)

--- a/src/statsbase_support.jl
+++ b/src/statsbase_support.jl
@@ -10,8 +10,8 @@ Statistics.mean(X::AbstractVectorOfSimilarArrays{T,M}, w::StatsBase.AbstractWeig
 Statistics.var(X::AbstractVectorOfSimilarArrays{T,M}, w::StatsBase.AbstractWeights; corrected::Bool = true) where {T,M} =
     var(flatview(X), w, M + 1; corrected = corrected)[_ncolons(Val{M}())...]
 
-Statistics.std(X::AbstractVectorOfSimilarArrays{T,M}, w::StatsBase.AbstractWeights; corrected::Bool = true) where {T,M} =
-    std(flatview(X), w, M + 1; corrected = corrected)[_ncolons(Val{M}())...]
+Statistics.std(X::AbstractVectorOfSimilarArrays{T,M}, w::StatsBase.AbstractWeights; mean = nothing, corrected::Bool = true) where {T,M} =
+    std(flatview(X), w, M + 1; mean = mean, corrected = corrected)[_ncolons(Val{M}())...]
 
 Statistics.cov(X::AbstractVectorOfSimilarVectors, w::StatsBase.AbstractWeights; corrected::Bool = true) =
     cov(flatview(X), w, 2; corrected = corrected)

--- a/src/statsbase_support.jl
+++ b/src/statsbase_support.jl
@@ -13,8 +13,8 @@ Statistics.var(X::AbstractVectorOfSimilarArrays{T,M}, w::StatsBase.AbstractWeigh
 Statistics.std(X::AbstractVectorOfSimilarArrays{T,M}, w::StatsBase.AbstractWeights; mean = nothing, corrected::Bool = true) where {T,M} =
     std(flatview(X), w, M + 1; mean = mean, corrected = corrected)[_ncolons(Val{M}())...]
 
-Statistics.cov(X::AbstractVectorOfSimilarVectors, w::StatsBase.AbstractWeights; mean = nothing, corrected::Bool = true) =
-    cov(flatview(X), w, 2; mean = mean, corrected = corrected)
+Statistics.cov(X::AbstractVectorOfSimilarVectors, w::StatsBase.AbstractWeights; corrected::Bool = true) =
+    cov(flatview(X), w, 2; mean = corrected = corrected)
 
 Statistics.cor(X::AbstractVectorOfSimilarVectors, w::StatsBase.AbstractWeights) =
     cor(flatview(X), w, 2)

--- a/src/statsbase_support.jl
+++ b/src/statsbase_support.jl
@@ -14,7 +14,7 @@ Statistics.std(X::AbstractVectorOfSimilarArrays{T,M}, w::StatsBase.AbstractWeigh
     std(flatview(X), w, M + 1; mean = mean, corrected = corrected)[_ncolons(Val{M}())...]
 
 Statistics.cov(X::AbstractVectorOfSimilarVectors, w::StatsBase.AbstractWeights; corrected::Bool = true) =
-    cov(flatview(X), w, 2; mean = corrected = corrected)
+    cov(flatview(X), w, 2; corrected = corrected)
 
 Statistics.cor(X::AbstractVectorOfSimilarVectors, w::StatsBase.AbstractWeights) =
     cor(flatview(X), w, 2)


### PR DESCRIPTION
This matches the functions signatures in `Base` where the `mean` can be passed as kwarg.
This allows the generic fallback of `mean_and_std` to work for example.

Should I add some tests as well?