### PR TITLE
fix `nestedview` docstring

### DIFF
--- a/src/functions.jl
+++ b/src/functions.jl
@@ -55,7 +55,7 @@ export flatview
 
 AbstractArray{<:AbstractArray{T,M},N}
 
-View array `A` in as an `M`-dimensional array of `N`-dimensional arrays by
+View array `A` in as an `N`-dimensional array of `M`-dimensional arrays by
 wrapping it into an [`ArrayOfSimilarArrays`](@ref).
 
 It's also possible to use a `StaticVector` of length `S` as the type of the


### PR DESCRIPTION
the N and M are backwards in the docstring:

```
julia> Af=reshape(1:3*3*5, 3,3,5);

julia> size(Af)
(3, 3, 5)

julia> An=nestedview(Af,2);

julia> size(An)
(5,)

julia> size(An[1])
(3, 3)

julia> ndims(An[1])
2
```