### PR TITLE
Reduce over the flat data in mapreduce with maximum, minimum and sum

### DIFF
--- a/src/array_of_similar_arrays.jl
+++ b/src/array_of_similar_arrays.jl
@@ -394,6 +394,31 @@ Base.convert(R::Type{VectorOfSimilarVectors}, A::AbstractVector{<:AbstractVector
 # does not dispatch on keyword arguments, so dispatch on the value of `dims`
 # instead and forward non-Colon dims to the generic implementations:
 
+# Reductions that combine per-element reductions with the same operation
+# run over the flat data in a single pass. Empty inputs and empty elements
+# go to the generic implementation, to preserve its errors:
+for (f, op) in ((:maximum, :max), (:minimum, :min))
+    @eval function Base.mapreduce(::typeof($f), ::typeof($op), A::AbstractArrayOfSimilarArrays; kwargs...)
+        if isempty(kwargs) && !isempty(A) && prod(innersize(A)) > 0
+            $f(fused(A))
+        else
+            invoke(mapreduce, Tuple{typeof($f),typeof($op),AbstractArray}, $f, $op, A; kwargs...)
+        end
+    end
+end
+
+# The flat sum is Base's (pairwise) sum over the flat data, so for
+# floating-point elements it may differ from the element-wise grouping by
+# the last bits, like any reassociated sum:
+function Base.mapreduce(::typeof(sum), ::typeof(+), A::AbstractArrayOfSimilarArrays; kwargs...)
+    if isempty(kwargs) && !isempty(A)
+        sum(fused(A))
+    else
+        invoke(mapreduce, Tuple{typeof(sum),typeof(+),AbstractArray}, sum, +, A; kwargs...)
+    end
+end
+
+
 _flatreduce(f, X::AbstractVectorOfSimilarArrays{T,M}, ::Colon; kwargs...) where {T,M} =
     f(flatview(X); dims = M + 1, kwargs...)[_ncolons(Val{M}())...]
 _flatreduce(f, X::AbstractVectorOfSimilarArrays, dims::Integer; kwargs...) =

--- a/src/vector_of_arrays.jl
+++ b/src/vector_of_arrays.jl
@@ -493,6 +493,30 @@ end
 Base.mapreduce(::typeof(vec), ::typeof(vcat), A::VectorOfArrays) = copy(vecflattened(A))
 Base.reduce(::typeof(vcat), A::VectorOfArrays{T,1}) where {T} = copy(vecflattened(A))
 
+# Reductions that combine per-element reductions with the same operation
+# run over the covered flat data in a single pass. Empty inputs and empty
+# elements go to the generic implementation, to preserve its errors:
+for (f, op) in ((:maximum, :max), (:minimum, :min))
+    @eval function Base.mapreduce(::typeof($f), ::typeof($op), A::VectorOfArrays; kwargs...)
+        if isempty(kwargs) && !isempty(A) && !any(iszero, innerlengths(A))
+            $f(vecflattened(A))
+        else
+            invoke(mapreduce, Tuple{typeof($f),typeof($op),AbstractArray}, $f, $op, A; kwargs...)
+        end
+    end
+end
+
+# The flat sum is Base's (pairwise) sum over the covered data, so for
+# floating-point elements it may differ from the element-wise grouping by
+# the last bits, like any reassociated sum:
+function Base.mapreduce(::typeof(sum), ::typeof(+), A::VectorOfArrays; kwargs...)
+    if isempty(kwargs) && !isempty(A)
+        sum(vecflattened(A))
+    else
+        invoke(mapreduce, Tuple{typeof(sum),typeof(+),AbstractArray}, sum, +, A; kwargs...)
+    end
+end
+
 
 Base.size(A::VectorOfArrays) = size(A.kernel_size)
 

--- a/test/array_of_similar_arrays.jl
+++ b/test/array_of_similar_arrays.jl
@@ -367,6 +367,23 @@ end
     end
 
 
+    @testset "flat reductions" begin
+        A = sliced(reshape(collect(1.0:12.0), 3, 4), 1)
+        R = collect(A)
+        for (f, op) in ((maximum, max), (minimum, min), (sum, +))
+            @test @inferred(mapreduce(f, op, A)) == mapreduce(f, op, R)
+            @test mapreduce(f, op, A; init = 100.0) == mapreduce(f, op, R; init = 100.0)
+        end
+
+        # Empty inputs and empty elements behave like the generic implementation:
+        E = sliced(zeros(3, 0), 1)
+        @test_throws _reduction_error_type(maximum, max, collect(E)) mapreduce(maximum, max, E)
+        @test_throws _reduction_error_type(sum, +, collect(E)) mapreduce(sum, +, E)
+        Z = sliced(zeros(0, 3), 1)
+        @test_throws _reduction_error_type(maximum, max, collect(Z)) mapreduce(maximum, max, Z)
+        @test mapreduce(sum, +, Z) == 0.0
+    end
+
     @testset "zero-dimensional elements" begin
         A = sliced(collect(1:5), Val(0))
         A[1] = fill(9)

--- a/test/gpu_arrays.jl
+++ b/test/gpu_arrays.jl
@@ -121,6 +121,18 @@ JLArrays.allowscalar(false)
         @test_throws ArgumentError ArraysOfArrays.FuseArrays(getsplitmode(V_host))(V2_dev)
     end
 
+    @testset "flat reductions on device" begin
+        V_host = VectorOfArrays([Float32[3, 1], Float32[7, -2, 5], Float32[4]])
+        for V in (VectorOfArrays(jl(V_host.data), V_host.elem_ptr, V_host.kernel_size), adapt(JLArray, V_host))
+            @test mapreduce(maximum, max, V) == 7
+            @test mapreduce(minimum, min, V) == -2
+            @test mapreduce(sum, +, V) == 18
+        end
+        A = sliced(jl(Float32[1 4; 2 5; 3 6]), 1)
+        @test mapreduce(maximum, max, A) == 6
+        @test mapreduce(sum, +, A) == 21
+    end
+
     @testset "device-resident shape info operations" begin
         V_host = VectorOfArrays([Float32[1, 2], Float32[3, 4, 5]])
         W_host = VectorOfArrays([Float32[1, 2], Float32[3, 4, 6]])

--- a/test/testdefs.jl
+++ b/test/testdefs.jl
@@ -185,3 +185,9 @@ if !isdefined(Main, :test_api)
         end
     end
 end
+
+
+# Base throws different error types for empty reductions across Julia
+# versions (ArgumentError on >=1.11, MethodError on 1.10), so tests assert
+# parity with the generic implementation instead of a fixed type:
+_reduction_error_type(f, op, A) = try mapreduce(f, op, A); nothing catch e; typeof(e) end

--- a/test/vector_of_arrays.jl
+++ b/test/vector_of_arrays.jl
@@ -54,6 +54,27 @@ include("testdefs.jl")
     end
 
 
+    @testset "flat reductions" begin
+        V = VectorOfArrays([[3.0, 1.0], [7.0, -2.0, 5.0], [4.0]])
+        R = collect(V)
+        for (f, op) in ((maximum, max), (minimum, min), (sum, +))
+            @test @inferred(mapreduce(f, op, V)) == mapreduce(f, op, R)
+            @test mapreduce(f, op, V; init = 0.5) == mapreduce(f, op, R; init = 0.5)
+        end
+        # Views only cover part of the data:
+        @test mapreduce(maximum, max, V[2:3]) == 7.0
+        @test mapreduce(sum, +, V[1:2]) == 14.0
+
+        # Empty inputs and empty elements behave like the generic implementation:
+        E = VectorOfArrays(Vector{Vector{Float64}}())
+        @test_throws _reduction_error_type(maximum, max, collect(E)) mapreduce(maximum, max, E)
+        @test_throws _reduction_error_type(sum, +, collect(E)) mapreduce(sum, +, E)
+        Z = VectorOfArrays([[1.0, 2.0], Float64[], [3.0]])
+        @test_throws _reduction_error_type(maximum, max, collect(Z)) mapreduce(maximum, max, Z)
+        @test_throws _reduction_error_type(minimum, min, collect(Z)) mapreduce(minimum, min, Z)
+        @test mapreduce(sum, +, Z) == 6.0
+    end
+
     @testset "element shape enforcement" begin
         # The element shape check must also fire under @inbounds, as in
         # broadcast assignment:


### PR DESCRIPTION
Specializes `mapreduce(maximum, max, A)`, `mapreduce(minimum, min, A)` and
`mapreduce(sum, +, A)` for `VectorOfArrays` and `ArrayOfSimilarArrays` to reduce
the covered flat data in a single pass. Besides avoiding per-element reductions,
this also works on device-resident data without scalar indexing.

Empty inputs and empty elements fall back to the generic implementation, so the
errors Base throws in those cases are preserved (`maximum` of an empty element,
reductions over an empty collection), and keyword arguments like `init` take the
generic path as well.

Supersedes #48 — thanks @pfackeldey for the idea and the original implementation.
