### PR TITLE
Keep VectorOfVectors as a supported alias of PartsView

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ArraysOfArrays"
 uuid = "65a8f2f4-9b39-5baf-92e2-a9cc46fdf018"
-version = "1.0.0"
+version = "1.0.1"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -135,6 +135,7 @@ all(x -> x == 4.2, VA[2])
 The following type aliases are defined:
 
 * `PartsView{T,VT,VI,VD,ET} = VectorOfArrays{T,1,0,VT,VI,VD,ET}`
+* `VectorOfVectors = PartsView`
 
 ### Appending data and resizing
 

--- a/src/vector_of_arrays.jl
+++ b/src/vector_of_arrays.jl
@@ -970,6 +970,10 @@ function consgroupedview(source::AbstractVector, target::NamedTuple{syms,<:NTupl
 end
 
 
-# Deprecated:
+"""
+    VectorOfVectors{T,...} = PartsView{T,...}
 
-Base.@deprecate_binding VectorOfVectors PartsView
+Alias for [`PartsView`](@ref).
+"""
+const VectorOfVectors = PartsView
+export VectorOfVectors

--- a/test/vector_of_arrays.jl
+++ b/test/vector_of_arrays.jl
@@ -119,6 +119,8 @@ include("testdefs.jl")
         @test @inferred(VectorOfArrays{Float64,1}(deepcopy(A1))) isa VectorOfArrays{Float64,1,0,Array{Float64,1},Array{Int,1},Array{Tuple{},1}}
         @test VectorOfArrays{Float64,1}(deepcopy(A1)) == A1
 
+        @test VectorOfVectors === PartsView
+        @test !Base.isdeprecated(ArraysOfArrays, :VectorOfVectors)
         @test @inferred(PartsView(deepcopy(A1))) isa VectorOfArrays{Float32,1,0,Array{Float32,1},Array{Int,1},Array{Tuple{},1}}
         @test PartsView(deepcopy(A1)) == A1
         @test @inferred(PartsView{Float64}(deepcopy(A1))) isa VectorOfArrays{Float64,1,0,Array{Float64,1},Array{Int,1},Array{Tuple{},1}}


### PR DESCRIPTION
Un-deprecates `VectorOfVectors`: it stays an exported, documented alias of `PartsView` (both names remain first-class), instead of a `@deprecate_binding` slated for removal in 2.0.

Rationale:

* `VectorOfVectors` is the established name of the vector-of-vectors member of the `VectorOfArrays` / `VectorOfSimilarVectors` type family and is used throughout the downstream ecosystem (SolidStateDetectors, UnROOT, LegendHDF5IO, ...). Every other change of v1 has a spelling that works on v0.6 and v1 alike, this rename was the only one forcing downstream code to carry version-conditional aliases.
* Deprecated-binding warnings are inconsistent across Julia versions: on 1.10 every unqualified use warns under `--depwarn=yes` (i.e. in every `Pkg.test`) with the expanded `VectorOfArrays{T, 1, 0, ...} where ...` in the message rather than `PartsView`, and throws under `--depwarn=error`, while on 1.12 unqualified use never warns at all.

Consequence to be aware of: with two exported aliases for the same type, Julia's alias printing selects neither, so `PartsView` instances now print with their underlying `VectorOfArrays{T, 1, 0, ...}` type instead of an alias name.

Non-breaking, patch release 1.0.1.

Created by generative AI.
