### PR TITLE
Support empty arrays of arrays in stacked

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ArraysOfArrays"
 uuid = "65a8f2f4-9b39-5baf-92e2-a9cc46fdf018"
-version = "1.0.1"
+version = "1.0.2"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -398,7 +398,9 @@ Join the element arrays of a nested array into a single array along one or
 more new dimensions, return non-nested arrays unchanged.
 
 Similar to `Base.stack`, but can return the original underlying array of
-sliced arrays in more cases.
+sliced arrays in more cases. Empty arrays of arrays, which `Base.stack`
+rejects, yield an empty array with the [`innersize`](@ref) of `A` as inner
+dimensions.
 """
 function stacked end
 export stacked
@@ -406,7 +408,8 @@ export stacked
 @inline stacked(A::AbstractArray) = A
 @inline stacked(A::AbstractArray{<:AbstractArray}) = _stacked_impl(A, getsplitmode(A))
 
-_stacked_impl(A::AbstractArray{<:AbstractArray}, ::AbstractSplitMode) = stack(A)
+_stacked_impl(A::AbstractArray{<:AbstractArray}, ::AbstractSplitMode) =
+    isempty(A) ? Array{eltype(eltype(A))}(undef, innersize(A)..., size(A)...) : stack(A)
 
 function _stacked_impl(A::AbstractSlices{<:AbstractArray}, smode::AbstractSlicingMode)
     A_joined = fused(A)

--- a/test/functions.jl
+++ b/test/functions.jl
@@ -160,6 +160,13 @@ include("testdefs.jl")
         test_api(A_3, A_3_flat)
     end
 
+    @testset "stacked" begin
+        @test @inferred(stacked(Vector{Vector{Float64}}())) == Matrix{Float64}(undef, 0, 0)
+        @test @inferred(stacked(Vector{Matrix{Int}}())) == Array{Int}(undef, 0, 0, 0)
+        @test @inferred(convert(VectorOfSimilarVectors, Vector{Vector{Float64}}())) == VectorOfSimilarVectors(Matrix{Float64}(undef, 0, 0))
+        @test isempty(@inferred(convert(ArrayOfSimilarArrays, Matrix{Vector{Float64}}(undef, 0, 2))))
+    end
+
     @testset "generic fallbacks" begin
         @test unstackmode(rand(2, 3)) === NonSplitMode{2}()
         @test unstackmode(AbstractArray[[1], [2, 3]]) isa UnknownSplitMode

--- a/test/testdefs.jl
+++ b/test/testdefs.jl
@@ -143,6 +143,13 @@ if !isdefined(Main, :test_api)
                 @test permutedims(A_unsplit_ref, (innerdims..., outerdims...)) == A_array_stacked
             elseif smode isa NonSplitMode
                 @test @inferred(stacked(A)) === A
+            elseif isempty(A)
+                # stacked returns an empty array with the innersize of A as
+                # inner dimensions, where Base.stack would reject the empty
+                # collection:
+                s = stacked(A)
+                @test isempty(s)
+                @test ndims(s) == ndims(eltype(A)) + ndims(A)
             else
                 stacked_A = try stack(A); catch err; err; end
                 if stacked_A isa Exception


### PR DESCRIPTION
Converting an empty array of arrays, e.g. `convert(VectorOfSimilarVectors, Vector{Vector{Float64}}())`, throws since v1.0.0 because the nested-array `convert` methods go through `stacked`, which defers to `Base.stack`, and `Base.stack` rejects empty collections. v0.6 returned an empty `ArrayOfSimilarArrays`, and downstream code relies on that.

`stacked` now returns an empty array with the `innersize` of its argument as inner dimensions for empty arrays of arrays, consistent with `innersize` being defined as zeros for empty generic arrays and with the known inner size of empty slices (`stacked(eachcol(zeros(3, 0)))` has size `(3, 0)`). Non-empty inputs are unchanged. Documented in the `stacked` docstring, tests added.

Patch release 1.0.2.

Created by generative AI.
