### PR TITLE
GPU map and scalar-result broadcast for VectorOfArrays

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ArraysOfArrays"
 uuid = "65a8f2f4-9b39-5baf-92e2-a9cc46fdf018"
-version = "1.0.2"
+version = "1.1.0"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -59,6 +59,8 @@ All four are zero-copy where possible and so may return arrays that share memory
 
 Both array types work with GPU-resident data. An `ArrayOfSimilarArrays` backed by a GPU array requires no special handling. For a `VectorOfArrays`, the shape information (`elem_ptr` and `kernel_size`) can either stay on the host, so that element access returns device views, or live on the device as well (e.g. via `Adapt.adapt`), which is the layout to use inside GPU kernels. Host-side element access (`V[i]`, iteration) requires the shape information on the host, as it would otherwise scalar-index device arrays. `KernelAbstractions.get_backend` returns the backend of the underlying data.
 
+Reductions over the flat data (`innersum`, `innerreduce`, `innermapreduce`) run as segmented device kernels. Generic `map(f, V)` and outer broadcasts `f.(V)` with scalar results also run on the device for a device-resident `VectorOfArrays` with **vector elements** (`VectorOfArrays{T,1}`), provided `f` is device-compatible (this includes `map(sum, V)`, which retains Base's `sum` semantics); the shape-insensitive reductions `maximum` and `minimum` (via `map(maximum, V)`/`map(minimum, V)`) additionally use the segmented reduction kernels for any element dimensionality, and `map(argmin, V)`/`map(argmax, V)` match Base (including `NaN` and signed-zero ordering) for vector elements. For `VectorOfArrays{T,N}` with `N > 1`, `map` keeps its generic behavior: it is correct when the shape information is host-resident and fails cleanly (rather than dropping the element shape) when it is device-resident.
+
 
 ## [ArrayOfSimilarArrays](@id section_ArrayOfSimilarArrays)
 

--- a/ext/ArraysOfArraysGPUKernelsExt.jl
+++ b/ext/ArraysOfArraysGPUKernelsExt.jl
@@ -7,7 +7,7 @@ using GPUArraysCore: AbstractGPUArray
 import KernelAbstractions as KA
 using KernelAbstractions: @kernel, @index, @Const
 
-using ArraysOfArrays: ArraysOfArrays, VectorOfArrays, innerlengths
+using ArraysOfArrays: ArraysOfArrays, VectorOfArrays, innerlengths, innerreduce, NestedArrayStyle
 
 
 @kernel function _segmented_mapreduce_kernel!(out, f, op, @Const(data), @Const(elem_ptr), init)
@@ -125,5 +125,126 @@ function ArraysOfArrays._innermapreduce_impl(f, op, init, A::VectorOfArrays{T,N,
 
     return _segmented_mapreduce(f, op, init, data, elem_ptr, T_out, backend)
 end
+
+
+# Vectors of arrays whose data lives on a device. The shape information may
+# be host- or device-resident:
+const _GPUVectorOfArrays{T,N,M} = VectorOfArrays{T,N,M,<:AbstractGPUArray}
+
+# The N == 1 (vector-element) case. Only here does the flat segment view
+# equal the logical element and does an element index reduce to a plain
+# linear Int, so only these use the segment-view kernels for the
+# shape-dependent operations (generic map, argmin/argmax):
+const _GPUVectorOfVectors{T,M} = VectorOfArrays{T,1,M,<:AbstractGPUArray}
+
+
+# Apply a whole-element function g to each element array. One work item per
+# element constructs a view and calls g on it, so g must be compilable for
+# the device (many Base reductions are, but those that throw on empty
+# collections, like maximum, are not - those are routed to the segmented
+# reduction kernels instead, see below):
+@kernel function _segmented_map_kernel!(out, g, @Const(data), @Const(elem_ptr))
+    i = @index(Global, Linear)
+    j0 = elem_ptr[i]
+    j1 = elem_ptr[i + 1] - 1
+    @inbounds out[i] = g(view(data, j0:j1))
+end
+
+# Defer to the generic map (correct for host-resident shape info; a clean
+# scalar-indexing error for device-resident shape info) instead of forcing a
+# result through the segment-view kernel:
+_segmented_map_fallback(g, A) = invoke(map, Tuple{Any, AbstractArray}, g, A)
+
+function _segmented_map(g, A::_GPUVectorOfArrays)
+    # The flat segment view only equals the logical element for vector
+    # elements; for N > 1 it would drop the element shape, so defer:
+    ndims(eltype(A)) == 1 || return _segmented_map_fallback(g, A)
+    T_out = Base.promote_op(g, eltype(A))
+    # Array results (or a type that did not infer to something concrete)
+    # cannot go through the scalar-result kernel; defer to the generic map,
+    # mirroring the scalar-result guard in the broadcast path below:
+    (isconcretetype(T_out) && !(T_out <: AbstractArray)) || return _segmented_map_fallback(g, A)
+    data = A.data
+    backend = KA.get_backend(data)
+    elem_ptr = _on_backend(backend, A.elem_ptr)
+    n = length(A)
+    out = KA.allocate(backend, T_out, n)
+    n > 0 && _segmented_map_kernel!(backend)(out, g, data, elem_ptr; ndrange = n)
+    return out
+end
+
+
+# Per-element argmin/argmax for vector elements. Base.argmin/argmax do not
+# compile for the device (their empty-collection handling throws), so the
+# index-tracking loop is written out. The update predicate mirrors Base's
+# findmax/findmin reducers (isless for argmax, Base.isgreater for argmin), so
+# ties keep the first extremum and NaN/-0.0 order exactly like Base:
+@kernel function _seg_argextreme_kernel!(out, better, @Const(data), @Const(elem_ptr))
+    i = @index(Global, Linear)
+    j0 = elem_ptr[i]
+    j1 = elem_ptr[i + 1] - 1
+    @inbounds best = data[j0]
+    bestidx = 1
+    for j in (j0 + 1):j1
+        @inbounds v = data[j]
+        if better(best, v)
+            best = v
+            bestidx = j - j0 + 1
+        end
+    end
+    @inbounds out[i] = bestidx
+end
+
+function _segmented_argextreme(better, A::_GPUVectorOfVectors)
+    any(iszero, innerlengths(A)) && throw(ArgumentError("Cannot take argmin/argmax of empty element arrays"))
+    data = A.data
+    backend = KA.get_backend(data)
+    elem_ptr = _on_backend(backend, A.elem_ptr)
+    n = length(A)
+    out = KA.allocate(backend, Int, n)
+    n > 0 && _seg_argextreme_kernel!(backend)(out, better, data, elem_ptr; ndrange = n)
+    return out
+end
+
+
+# map over the element arrays of a device-resident vector of arrays, without
+# host-side scalar indexing. The general path uses the segment-view kernel
+# only for vector elements with a scalar result and defers everything else to
+# the generic map (see _segmented_map); shape-insensitive reductions are
+# routed to the segmented reduction kernels and stay valid for any element
+# dimensionality:
+Base.map(g, A::_GPUVectorOfArrays) = _segmented_map(g, A)
+# identity returns the element arrays, not scalars, so it keeps the generic
+# outer-copy behavior (disambiguation against map(::typeof(identity), ...)):
+Base.map(f::typeof(identity), A::_GPUVectorOfArrays) = invoke(map, Tuple{typeof(identity), VectorOfArrays}, f, A)
+# maximum/minimum are shape-insensitive and keep Base's element type, so they
+# use the chunked segmented reduction for any element dimensionality. sum is
+# deliberately not routed here: Base's sum widens small integers via add_sum
+# (e.g. sum(Int8[100, 28]) == 128::Int), which innersum's plain + does not, so
+# sum is left to the general segment-view kernel (N == 1, which reproduces
+# Base's sum) and the generic map fallback (N > 1):
+Base.map(::typeof(maximum), A::_GPUVectorOfArrays) = innerreduce(max, A)
+Base.map(::typeof(minimum), A::_GPUVectorOfArrays) = innerreduce(min, A)
+# argmin/argmax return an index into the element, which is a plain linear Int
+# only for vector elements; higher-dimensional elements would need Cartesian
+# indices, so these are restricted to N == 1 and larger element
+# dimensionalities fall back to the generic map (see _segmented_map):
+Base.map(::typeof(argmin), A::_GPUVectorOfVectors) = _segmented_argextreme(Base.isgreater, A)
+Base.map(::typeof(argmax), A::_GPUVectorOfVectors) = _segmented_argextreme(isless, A)
+
+
+# Single-argument outer broadcast g.(A) with a scalar result over a
+# device-resident vector of arrays routes to the same kernel; array
+# results and fused/multi-argument broadcasts keep the generic behavior:
+function Base.copy(bc::Base.Broadcast.Broadcasted{NestedArrayStyle{1}, <:Any, F, <:Tuple{<:_GPUVectorOfArrays}}) where {F}
+    A = bc.args[1]
+    ElType = Base.Broadcast.combine_eltypes(bc.f, (A,))
+    if isconcretetype(ElType) && !(ElType <: AbstractArray)
+        return map(bc.f, A)
+    else
+        return Base.copy(Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1}}(bc.f, bc.args, bc.axes))
+    end
+end
+
 
 end # module ArraysOfArraysGPUKernelsExt

--- a/test/gpu_arrays.jl
+++ b/test/gpu_arrays.jl
@@ -164,4 +164,114 @@ JLArrays.allowscalar(false)
         V2 = VectorOfArrays(jl(collect(1f0:100000f0)), jl([1, 100001]), jl([()]))
         @test collect(innersum(V2)) ≈ [sum(1f0:100000f0)]
     end
+
+    @testset "map and broadcast with scalar results" begin
+        cpu = VectorOfArrays([Float32[3, 1, 4], Float32[9, 2], Float32[6, 5, 3, 1], Float32[7]])
+        # Both fully device-resident and host-shape-info layouts:
+        for V in (adapt(JLArray, cpu),
+                  VectorOfArrays(jl(cpu.data), cpu.elem_ptr, cpu.kernel_size))
+            for g in (sum, maximum, minimum, argmin, argmax)
+                @test Array(map(g, V)) == map(g, cpu)
+            end
+            # Broadcast form:
+            @test Array(sum.(V)) == sum.(cpu)
+            @test Array(argmin.(V)) == argmin.(cpu)
+            # A general scalar function via the segment-view kernel:
+            @test Array(map(v -> sum(abs2, v), V)) == map(v -> sum(abs2, v), cpu)
+            @test Array((v -> sum(abs2, v)).(V)) == (v -> sum(abs2, v)).(cpu)
+        end
+
+        # Empty vector of arrays:
+        @test isempty(map(sum, adapt(JLArray, VectorOfArrays(Vector{Float32}[]))))
+
+        # argmin/argmax of empty element arrays error like Base:
+        Ve = adapt(JLArray, VectorOfArrays([Float32[1, 2], Float32[]]))
+        @test_throws ArgumentError map(argmin, Ve)
+        @test_throws ArgumentError map(argmax, Ve)
+
+        # Array-result outer broadcast is not rerouted to the scalar path
+        # (host shape info, so no scalar indexing):
+        Vhs = VectorOfArrays(jl(cpu.data), cpu.elem_ptr, cpu.kernel_size)
+        r = (x -> x .+ 1f0).(Vhs)
+        @test length(r) == length(cpu)
+        @test Array(r[1]) == cpu[1] .+ 1f0
+
+        # identity keeps the outer-copy behavior (element arrays, not scalars):
+        Vid = map(identity, adapt(JLArray, cpu))
+        @test Vid isa VectorOfArrays && length(Vid) == length(cpu)
+    end
+
+    @testset "map: N>1 elements, fallback, and Base parity" begin
+        # Elements are matrices (N == 2). The generic segment-view kernel is
+        # restricted to vector elements, so map must not flatten these:
+        cpu2 = VectorOfArrays([reshape(Float32[1, 2, 3, 4], 2, 2),
+                               reshape(Float32[5, 6, 7, 8, 9, 10], 2, 3)])
+        Vhs2 = VectorOfArrays(jl(cpu2.data), cpu2.elem_ptr, cpu2.kernel_size)
+        Vdev2 = adapt(JLArray, cpu2)
+
+        # Host-resident shape info: map falls back to the generic path and
+        # stays correct (shape preserved, Cartesian indices from argmax):
+        @test map(ndims, Vhs2) == map(ndims, cpu2)
+        @test map(x -> size(x, 1), Vhs2) == map(x -> size(x, 1), cpu2)
+        @test map(argmax, Vhs2) == map(argmax, cpu2)
+        @test eltype(map(argmax, Vhs2)) <: CartesianIndex
+
+        # Device-resident shape info: no accelerated path exists for N > 1,
+        # so it must fail cleanly (scalar indexing) rather than return a
+        # silently flattened answer:
+        @test_throws ErrorException map(ndims, Vdev2)
+        @test_throws ErrorException map(argmax, Vdev2)
+
+        # Generic sum has no all-N specialization: it is correct for N > 1
+        # with host-resident shape info (generic fallback), but fully
+        # device-resident N > 1 has no generic map path and fails cleanly:
+        @test Array(map(sum, Vhs2)) == map(sum, cpu2)
+        @test_throws ErrorException map(sum, Vdev2)
+        # maximum/minimum are shape-insensitive and stay valid for N > 1 via
+        # the segmented reduction kernels, on both layouts:
+        for V2 in (Vhs2, Vdev2)
+            @test Array(map(maximum, V2)) == map(maximum, cpu2)
+            @test Array(map(minimum, V2)) == map(minimum, cpu2)
+        end
+
+        # Array-valued and non-concretely-inferred map over host-shape info
+        # keep their pre-specialization behavior (element views on the host):
+        cpu1 = VectorOfArrays([Float32[3, 1, 4], Float32[9, 2], Float32[7]])
+        Vhs1 = VectorOfArrays(jl(cpu1.data), cpu1.elem_ptr, cpu1.kernel_size)
+        r = map(x -> x .+ 1f0, Vhs1)
+        @test length(r) == length(cpu1)
+        @test all(Array(r[i]) == cpu1[i] .+ 1f0 for i in eachindex(cpu1))
+        g_ni = v -> sum(v) > 5 ? 1 : 1.5   # inferred as Union{Int,Float64}
+        @test !isconcretetype(Base.promote_op(g_ni, eltype(Vhs1)))
+        @test map(g_ni, Vhs1) == map(g_ni, cpu1)
+
+        # argmin/argmax match Base for NaN and signed zero (vector elements):
+        for vals in ([Float32[1, NaN], Float32[3, 2, NaN], Float32[NaN, NaN]],
+                     [Float32[-0.0, 0.0], Float32[0.0, -0.0], Float32[0.0, -0.0, 0.0]])
+            cpuN = VectorOfArrays(vals)
+            for V in (adapt(JLArray, cpuN),
+                      VectorOfArrays(jl(cpuN.data), cpuN.elem_ptr, cpuN.kernel_size))
+                @test Array(map(argmin, V)) == map(argmin, cpuN)
+                @test Array(map(argmax, V)) == map(argmax, cpuN)
+            end
+        end
+
+        # map(sum, ·) keeps Base's sum semantics: small integers widen via
+        # add_sum (sum(Int8[100,28]) == 128::Int), unlike innersum's plain +.
+        # maximum/minimum keep Base's (non-widening) element type:
+        cpu_i8 = VectorOfArrays([Int8[100, 28], Int8[], Int8[127, 1]])
+        dev_i8 = adapt(JLArray, cpu_i8)
+        @test Array(map(sum, dev_i8)) == map(sum, cpu_i8)
+        @test eltype(Array(map(sum, dev_i8))) == eltype(map(sum, cpu_i8))
+        cpu_mm = VectorOfArrays([Int8[100, 28], Int8[127, 1]])
+        dev_mm = adapt(JLArray, cpu_mm)
+        @test Array(map(maximum, dev_mm)) == map(maximum, cpu_mm)
+        @test eltype(Array(map(maximum, dev_mm))) == eltype(map(maximum, cpu_mm))
+    end
+
+    @testset "no method ambiguities in the GPU extension" begin
+        ext = Base.get_extension(ArraysOfArrays, :ArraysOfArraysGPUKernelsExt)
+        @test ext !== nothing
+        @test isempty(detect_ambiguities(ext))
+    end
 end


### PR DESCRIPTION
Makes `map(f, V)` and outer broadcasts `f.(V)` with **scalar results** run on the
device for a device-resident `VectorOfArrays`, instead of falling back to host-side
element iteration (which scalar-indexes the device arrays). Resolves the remaining gap
from #51, re-scoped as #65.

Before: `map(argmin, adapt(CuArray, V))` / `argmin.(V)` → `Scalar indexing is disallowed`.
After: they run as segmented device kernels.

**Design** (bounded, not per-op sprawl):
- One general **segment-view kernel**: one work item per element applies `f` to a view of
  its segment. Covers `sum`, `mean`, `count`, custom scalar `f`, … — anything device-compatible.
- Reductions whose Base implementation doesn't GPU-compile (`maximum`/`minimum`, whose empty
  path throws) are routed to the existing segmented reduction kernels (`innerreduce`).
- `argmin`/`argmax` use dedicated index-tracking kernels (Base's don't compile for the device).
- `identity` keeps its outer-copy behavior (returns the element arrays, not scalars).
- Broadcast: a single-argument scalar-result `f.(V)` over a device VoA routes to `map`; array
  results and fused/multi-argument broadcasts keep the generic behavior.

**Verified** on real CUDA (RTX 2000 Ada) and JLArrays under `allowscalar(false)`: `sum`,
`maximum`, `minimum`, `argmin`, `argmax`, and a custom `v -> sum(abs2, v)`, in both fully
device-resident and host-shape-info layouts; empty-VoA and empty-segment (argmin/argmax error
like Base) edge cases; CPU paths unchanged; `Test.detect_ambiguities` clean with all extensions
loaded. Tests added to `test/gpu_arrays.jl` (JLArrays, run in CI).

Not in scope (documented limitations): array-result outer broadcasts over a fully
device-resident VoA (host-side element access still needs host-resident shape info), and
`findmin`/`findmax`/`extrema` (would need their own index/tuple kernels — easy follow-ups).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
